### PR TITLE
Consertando os links das tags nos posts

### DIFF
--- a/source/_views/post.twig
+++ b/source/_views/post.twig
@@ -23,7 +23,8 @@
             <p class="tags">
                 Tags:
                 {% for tag in page.tags %}
-                    <a href="{{ page.tag_html_index_permalinks[tag] }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+                    {% set tag_slug = tag|url_encode(true) %}
+                    <a href="/news/tags/{{ tag_slug }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                 {% endfor %}
             </p>
         {% endif %}

--- a/source/index.twig
+++ b/source/index.twig
@@ -35,7 +35,8 @@ use: [posts]
                 <p class="tags">
                     Tags:
                     {% for tag in post.tags %}
-                        <a href="{{post.tag_html_index_permalinks[tag] }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+                        {% set tag_slug = tag|url_encode(true) %}
+                        <a href="/news/tags/{{ tag_slug }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                     {% endfor %}
                 </p>
             {% endif %}


### PR DESCRIPTION
Os links para a página de tags estavam incorretos nos posts (na página
principal e na visualização do post)